### PR TITLE
Refactors Logger to fix Rubocop warnings

### DIFF
--- a/lib/todo-txt/logger.rb
+++ b/lib/todo-txt/logger.rb
@@ -1,21 +1,24 @@
 require 'logger'
 
 module Todo
+  # Handles depreciation warnings and other issues related to API usage
   module Logger
-    def self.included base
+    def self.included(base)
       base.extend(self)
-    end
-
-    def self.logger= new_logger
-      @@logger = new_logger
-    end
-
-    def self.logger
-      @@logger ||= ::Logger.new(STDOUT)
     end
 
     def logger
       Todo::Logger.logger
+    end
+
+    class << self
+      # Sets a new logger object
+      attr_writer :logger
+
+      # Creates a new logger object
+      def logger
+        @logger ||= ::Logger.new(STDOUT)
+      end
     end
   end
 end


### PR DESCRIPTION
- Uses `class << self` instead of `@@` in `Logger`.
- Adds top-level docs for the class.
- Prefers `attr_writer` for trivial methods.
- Encloses definition arguments in parens.

Closes #18