### PR TITLE
Adds priority increment / decrement

### DIFF
--- a/lib/todo-txt/task.rb
+++ b/lib/todo-txt/task.rb
@@ -191,6 +191,26 @@ module Todo
       @priority = orig_priority(orig)
     end
 
+    # Increases the priority until A. If it's nil, it sets it to A.
+    # @return [Char] the new priority of the task
+    def priority_inc!
+      if @priority.nil?
+        @priority = 'A'
+      elsif @priority.ord > 65
+        @priority = (@priority.ord - 1).chr
+      end
+      @priority
+    end
+
+    # Decreases the priority until Z. if it's nil, it does nothing and
+    # returns nil.
+    # @return [Char] the new priority of the task
+    def priority_dec!
+      return if @priority.nil?
+      @priority = @priority.next if @priority.ord < 90
+      @priority
+    end
+
     # Toggles the task from complete to incomplete or vice versa.
     #
     # Example:

--- a/spec/todo-txt/task_spec.rb
+++ b/spec/todo-txt/task_spec.rb
@@ -71,6 +71,78 @@ describe Todo::Task do
     end
   end
 
+  describe 'Step priority:' do
+    context 'Increment' do
+      it 'increments the priority by one' do
+        task = Todo::Task.new '(B) Task'
+        task.priority_inc!
+        expect(task.priority).to eq('A')
+      end
+
+      it 'returns the new priority' do
+        task = Todo::Task.new '(B) Task'
+        expect(task.priority_inc!).to eq('A')
+      end
+
+      it 'does not increment priority beyond A' do
+        task = Todo::Task.new '(A) Task'
+        task.priority_inc!
+        expect(task.priority).to eq('A')
+      end
+
+      it 'returns A if the priority did not change' do
+        task = Todo::Task.new '(A) Task'
+        expect(task.priority_inc!).to eq('A')
+      end
+
+      it 'sets a priority if previous priority was nil' do
+        task = Todo::Task.new 'Task'
+        task.priority_inc!
+        expect(task.priority).to eq('A')
+      end
+
+      it 'returns A if the previous priority was nil' do
+        task = Todo::Task.new 'Task'
+        expect(task.priority_inc!).to eq('A')
+      end
+    end
+
+    context 'Decrement' do
+      it 'lowers the priority by one' do
+        task = Todo::Task.new '(A) Task'
+        task.priority_dec!
+        expect(task.priority).to eq('B')
+      end
+
+      it 'returns the new priority' do
+        task = Todo::Task.new '(A) Task'
+        expect(task.priority_dec!).to eq('B')
+      end
+
+      it 'does not go below Z' do
+        task = Todo::Task.new '(Z) Task'
+        task.priority_dec!
+        expect(task.priority).to eq('Z')
+      end
+
+      it 'returns Z if priority did not change' do
+        task = Todo::Task.new '(Z) Task'
+        expect(task.priority_dec!).to eq('Z')
+      end
+
+      it 'does not set a priority if priority was nil' do
+        task = Todo::Task.new 'Task'
+        task.priority_dec!
+        expect(task.priority).to eq(nil)
+      end
+
+      it 'returns nil if priority was nil' do
+        task = Todo::Task.new 'Task'
+        expect(task.priority_dec!).to eq(nil)
+      end
+    end
+  end
+
   describe 'Completion:' do
     it 'should be not done with missing date' do
       task = Todo::Task.new 'x This is not done'


### PR DESCRIPTION
These functions set and update priorities. They move letters
up and down by one, based on the ordinal alphabet, based
on the todo.txt spec.

If a task does not have a priority, increment sets it to a
default value of (A), while decrement makes no change.
This pattern is used in other apps like todotxt.net,
which has a large number of users. Because of this wide
adoption, these functions follow the same design.

The inc/dec functions return the new value of the item.
This can be used to check if the value has changed without
having to call #priority on the instance again.