### PR TITLE
Add customizable options

### DIFF
--- a/lib/todo-txt.rb
+++ b/lib/todo-txt.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'logger'
 require 'todo-txt/logger'
+require 'todo-txt/options'
 require 'todo-txt/syntax'
 require 'todo-txt/list'
 require 'todo-txt/task'

--- a/lib/todo-txt/options.rb
+++ b/lib/todo-txt/options.rb
@@ -1,0 +1,35 @@
+module Todo
+  class << self
+    attr_accessor :options_instance
+  end
+
+  def self.options
+    self.options_instance ||= Options.new
+  end
+
+  def self.customize
+    self.options_instance ||= Options.new
+    yield(options_instance)
+  end
+
+  class Options
+    # Require all done tasks to have a `completed_on` date. True by default.
+    #
+    # - When `true`, tasks with invalid dates are considered not done.
+    # - When `false`, tasks starting with `x ` are considered done.
+    attr_accessor :require_completed_on
+
+    # Whether or not to preserve original field order for roundtripping.
+    attr_accessor :maintain_field_order
+
+    def initialize
+      reset
+    end
+
+    # Reset to defaults.
+    def reset
+      @require_completed_on = true
+      @maintain_field_order = false
+    end
+  end
+end

--- a/lib/todo-txt/options.rb
+++ b/lib/todo-txt/options.rb
@@ -13,13 +13,21 @@ module Todo
   end
 
   class Options
+    # PENDING
+    #
     # Require all done tasks to have a `completed_on` date. True by default.
     #
     # - When `true`, tasks with invalid dates are considered not done.
     # - When `false`, tasks starting with `x ` are considered done.
+    #
+    # @return [Boolean]
     attr_accessor :require_completed_on
 
+    # PENDING
+    #
     # Whether or not to preserve original field order for roundtripping.
+    #
+    # @return [Boolean]
     attr_accessor :maintain_field_order
 
     def initialize

--- a/spec/todo-txt/options_spec.rb
+++ b/spec/todo-txt/options_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Todo::Options do
+  it 'should be available by default in the top-level module' do
+    expect(Todo.options).to be_a Todo::Options
+  end
+
+  it 'should provide require_completed_on as true by default' do
+    expect(Todo.options.require_completed_on).to be true
+  end
+
+  it 'should provide maintain_field_order as false by default' do
+    expect(Todo.options.maintain_field_order).to be false
+  end
+
+  it 'should support customization' do
+    Todo.customize do |options|
+      options.require_completed_on = false
+    end
+
+    expect(Todo.options.require_completed_on).to be false
+  end
+
+  after(:all) do
+    Todo.options.reset
+  end
+end


### PR DESCRIPTION
This provides the capability to set custom options to control various aspects of list and task behaviour.

It’s filled in with the following suggested options by default:

- require_completed_on
- maintain_field_order

FYI: @lorentrogers 