### PR TITLE
Adds a file save function

### DIFF
--- a/lib/todo-txt/list.rb
+++ b/lib/todo-txt/list.rb
@@ -104,5 +104,10 @@ module Todo
     def by_not_done
       Todo::List.new self.select { |task| task.done? == false }
     end
+
+    # saves the list to the original file location.
+    def save!
+      File.open(@original_filename, 'w') { |file| file << @list.join("\n") }
+    end
   end
 end


### PR DESCRIPTION
This commit adds Todo::List#save!, which writes the current
state of the list to the original file location.

Closes #5 

---

Probably not ready for prime-time just yet. I'll need some proper testing to ensure that the files are properly written. (e.g. line endings, edge-case scenarios like empty lists, etc.) I figured I would open this now so that we can discuss the approach as it goes along.