### PR TITLE
Allow list to be deduplicated

### DIFF
--- a/lib/todo/list.rb
+++ b/lib/todo/list.rb
@@ -115,13 +115,20 @@ module Todo
     # Saves the list to the original file location.
     #
     # Warning: This is a destructive operation and will overwrite any existing
-    # content in the file. It does not attempt to diff and append changes.
+    # content in the file.
     #
     # If no `path` is specified in the constructor then an error is raised.
     def save!
       raise "No path specified." unless path
 
+      self.deduplicate!
+
       File.write(path, self)
+    end
+
+    # Remove duplicated tasks
+    def deduplicate!
+      self.uniq! { |t| t.raw }
     end
   end
 end

--- a/spec/todo-txt/list_spec.rb
+++ b/spec/todo-txt/list_spec.rb
@@ -141,4 +141,20 @@ describe Todo::List do
   # Class should still be Todo::List
   # This assertion currently fails. TODO.
   # expect(list.sort).to be_a Todo::List
+
+  it 'should return a list without duplicated tasks' do
+    original_size = list.length
+
+    elements_to_clone = 4
+
+    elements_to_clone.times { |i|
+      list.push(list[i].clone)
+    }
+
+    expect(list.length).to be (original_size + elements_to_clone)
+
+    list.deduplicate!
+
+    expect(list.length).to be original_size
+  end
 end


### PR DESCRIPTION
Similar to the deduplicate function that's part of the main branch of the todo-txt shell script.